### PR TITLE
add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+bower_components
+*.db


### PR DESCRIPTION
Hi Wei, without gitignore, git goes nuts adding node modules and bower dependencies to the cloned repo; not a nice thing.